### PR TITLE
Watch for selectors defined in the actual file

### DIFF
--- a/test/rules/check-unused-flux-dependencies/test.10.tsx.lint
+++ b/test/rules/check-unused-flux-dependencies/test.10.tsx.lint
@@ -1,0 +1,21 @@
+import { show, hide } from 'selectors/some';
+
+const superSelect = select([show, hide], () => {
+  return {
+    a: show(),
+    b: hide(),
+  }
+})
+
+export default connect([show, hide, superSelect], () => ({
+                                    ~~~~~~~~~~~            [The "superSelect" dependency  is unused. This has performance impact!]
+  a: show(),
+  b: hide(),
+}))(component);
+
+export default connect([show, hide], () => ({
+  a: show(),
+  b: hide(),
+  b: superSelect()
+     ~~~~~~~~~~~   [You forgot to listen for the "superSelect" dependency!]
+}))(component);

--- a/test/rules/check-unused-flux-dependencies/test.8.tsx.lint
+++ b/test/rules/check-unused-flux-dependencies/test.8.tsx.lint
@@ -1,0 +1,14 @@
+import { show, hide } from 'selectors/some';
+
+const anotherSelect = select([show, hide], () => {
+  return {
+    a: show(),
+    b: hide(),
+  }
+})
+
+export default select([anotherSelect], () => {
+  return {
+    magic: anotherSelect(),
+  }
+})

--- a/test/rules/check-unused-flux-dependencies/test.9.tsx.lint
+++ b/test/rules/check-unused-flux-dependencies/test.9.tsx.lint
@@ -1,0 +1,15 @@
+import { show, hide } from 'selectors/some';
+
+const anotherSelect = select([show, hide], () => {
+  return {
+    a: show(),
+    b: hide(),
+  }
+})
+
+export default select([], () => {
+  return {
+    magic: anotherSelect(),
+           ~~~~~~~~~~~~~    [You forgot to listen for the "anotherSelect" dependency!]
+  }
+})


### PR DESCRIPTION
The flux dependencies should be considered the same as imports. So you should be notified when you are using selector in other selector or connect without listening on it.

I personally consider this as a fix. So I would bump the rule to 2.0.1. Ideas?

close #20 