### PR TITLE
Each Flux dependency (Store, Selector) should be watched as Identifier

### DIFF
--- a/test/rules/check-unused-flux-dependencies/test.11.tsx.lint
+++ b/test/rules/check-unused-flux-dependencies/test.11.tsx.lint
@@ -1,0 +1,31 @@
+import { show } from 'selectors/some';
+
+const superSelect = select([show], () => show());
+
+function superCalculate(dependence){
+  return 0;
+}
+
+export default connect([show, superSelect], () => ({
+  a: superCalculate(superSelect, show)
+}))(component);
+
+export default connect([show], () => ({
+  a: superCalculate(superSelect, show)
+                    ~~~~~~~~~~~        [You forgot to listen for the "superSelect" dependency!]
+}))(component);
+
+export default connect([superSelect], () => ({
+  a: superCalculate(superSelect, show)
+                                 ~~~~        [You forgot to listen for the "show" dependency!]
+}))(component);
+
+export default select([show], () => ({
+  a: superCalculate(superSelect, show)
+                    ~~~~~~~~~~~        [You forgot to listen for the "superSelect" dependency!]
+}))(component);
+
+export default select([superSelect], () => ({
+  a: superCalculate(superSelect, show)
+                                 ~~~~        [You forgot to listen for the "show" dependency!]
+}))(component);


### PR DESCRIPTION
Since we have established rule that from `selectors` there should be imported only Selectors and as a default export imported from `stores` there has to be Store. There is no need to make the logic so complicated, taking into account that current severity of this rule is warning. Once the watched identifier is used, we should analyze it. 

Fixes #23 