### PR TITLE
fix(import-group-order): wrong sorting of named imports

### DIFF
--- a/src/rules/importGroupOrderRule.ts
+++ b/src/rules/importGroupOrderRule.ts
@@ -59,23 +59,26 @@ type NormalizedConfiguration = {
 
 function formatImport(text: ImportType["i"]["text"], moduleSpecifier: string) {
   const namedImportsRegex = /{(([a-zA-Z0-9]*[, ]?)*)}/;
+  // let's omit the code style (new lines) entirely, it's prettier's job
+  let inlinedText = text.replace(/\n/g, "");
 
-  const matches = text.match(namedImportsRegex);
+  const matches = inlinedText.match(namedImportsRegex);
 
   if (!matches) return text;
 
   const namedImports = matches[1]
     .split(",")
     .map(a => a.trim())
+    .filter(a => a)
     .sort()
     .join(", ");
 
   // with syntax * as there might be moduleSpecifier ommited, so we need to reconstruct it.
-  if (!text.includes("from")) {
-    text += ` from '${moduleSpecifier}'`;
+  if (!inlinedText.includes("from")) {
+    inlinedText += ` from '${moduleSpecifier}'`;
   }
 
-  return text.replace(namedImportsRegex, `{ ${namedImports} }`);
+  return inlinedText.replace(namedImportsRegex, `{ ${namedImports} }`);
 }
 
 function isAbsolute(text: string) {

--- a/test/rules/import-group-order/test.1.tsx.fix
+++ b/test/rules/import-group-order/test.1.tsx.fix
@@ -1,11 +1,6 @@
 import a from 'libs/flux/r';
 import { b } from 'libs/flux/r';
-import {
-  c,
-  d,
-  f,
-  g,
-} from 'modules/views/libs/v';
+import { c, d, f, g } from 'modules/views/libs/v';
 
 import { h } from 'stores/u';
 

--- a/test/rules/import-group-order/test.4.tsx.fix
+++ b/test/rules/import-group-order/test.4.tsx.fix
@@ -1,11 +1,6 @@
 import a from 'libs/flux/r';
 import { b } from 'libs/flux/r';
-import {
-  c,
-  d,
-  f,
-  g,
-} from 'modules/views/libs/v';
+import { c, d, f, g } from 'modules/views/libs/v';
 
 import { h } from 'stores/u';
 

--- a/test/rules/import-group-order/test.6.tsx.fix
+++ b/test/rules/import-group-order/test.6.tsx.fix
@@ -1,0 +1,3 @@
+import { SpaceMembership, SubscriptionPlan, SubscriptionPlanInterval, User } from 'stores/types';
+
+console.log('test')

--- a/test/rules/import-group-order/test.6.tsx.lint
+++ b/test/rules/import-group-order/test.6.tsx.lint
@@ -1,0 +1,5 @@
+import { SubscriptionPlan, SubscriptionPlanInterval, SpaceMembership, User } from 'stores/types';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [Import convention has been violated. This is auto-fixable.]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [Named imports are not sorted in alphabetical order]
+
+console.log('test')

--- a/test/rules/import-group-order/test.7.tsx.fix
+++ b/test/rules/import-group-order/test.7.tsx.fix
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Space, Subscription, SubscriptionSwag, User } from 'something';
+
+import { action } from '@storybook/addon-actions';
+
+import B from './B.react';
+
+import { withSmartKnobs } from '@productboard/storybook-addon-smart-knobs';
+import { storiesOf } from '@storybook/react';
+
+storiesOf('B', module)
+  .addDecorator(withSmartKnobs)
+  .add('B', () => (
+    <B type="primary"/>
+  ));

--- a/test/rules/import-group-order/test.7.tsx.lint
+++ b/test/rules/import-group-order/test.7.tsx.lint
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import { action } from '@storybook/addon-actions';
+import { storiesOf } from '@storybook/react';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [Insert line above.]
+
+import {
+~~~~~~~~
+  Subscription,
+~~~~~~~~~~~~~~~
+  SubscriptionSwag,
+~~~~~~~~~~~~~~~~~~~
+  Space,
+~~~~~~~~
+  User,
+~~~~~~~
+} from 'something';
+~~~~~~~~~~~~~~~~~~~ [Named imports are not sorted in alphabetical order]
+
+import B from './B.react';
+import { withSmartKnobs } from '@productboard/storybook-addon-smart-knobs';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [Import convention has been violated. This is auto-fixable.]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [Insert line above.]
+
+storiesOf('B', module)
+  .addDecorator(withSmartKnobs)
+  .add('B', () => (
+    <B type="primary"/>
+  ));


### PR DESCRIPTION
The named imports which were multilined weren't sorted properly. We have decided to omit the code-style in order to transform data more easily.
Prettier will do its job later :)

Close #28 