### PR TITLE
Fixed special case when identifier has _

### DIFF
--- a/src/rules/importGroupOrderRule.ts
+++ b/src/rules/importGroupOrderRule.ts
@@ -58,7 +58,7 @@ type NormalizedConfiguration = {
 };
 
 function formatImport(text: ImportType["i"]["text"], moduleSpecifier: string) {
-  const namedImportsRegex = /{(([a-zA-Z0-9]*[, ]?)*)}/;
+  const namedImportsRegex = /{(.*)}/;
   // let's omit the code style (new lines) entirely, it's prettier's job
   let inlinedText = text.replace(/\n/g, "");
 

--- a/test/rules/import-group-order/test.8.tsx.fix
+++ b/test/rules/import-group-order/test.8.tsx.fix
@@ -1,0 +1,5 @@
+import React from 'react';
+
+import { a, action as b } from '@storybook/addon-actions';
+
+console.log('a');

--- a/test/rules/import-group-order/test.8.tsx.lint
+++ b/test/rules/import-group-order/test.8.tsx.lint
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import { action as b, a } from '@storybook/addon-actions';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [Import convention has been violated. This is auto-fixable.]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [Named imports are not sorted in alphabetical order]
+
+console.log('a');

--- a/test/rules/import-group-order/test.9.tsx.lint
+++ b/test/rules/import-group-order/test.9.tsx.lint
@@ -1,0 +1,20 @@
+import FeStore, {
+~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
+  Filip,
+~~~~~~~~
+~~~~~~~~
+  sortByKarel,
+~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
+  sortByPepa,
+~~~~~~~~~~~~~
+~~~~~~~~~~~~~
+  UNSORTED_SROT,
+~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
+} from 'something';
+~~~~~~~~~~~~~~~~~~~ [Import convention has been violated. This is auto-fixable.]
+~~~~~~~~~~~~~~~~~~~ [Named imports are not sorted in alphabetical order]
+
+console.log('a');


### PR DESCRIPTION
The regex for named imports
```js
/{(([a-zA-Z0-9]*[, ]?)*)}/;
```

is wrong

```js
/{(([a-zA-Z0-9_]*[, ]?)*)}/;
```

which is basically 

```js
/{((\w*[, ]?)*)}/;
```

but it's still unnecessary complex, simple `{(.*)}` should do the trick (and it does :) )!