### PR TITLE
rule: `selectors-format`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ These are highly experimental rules we are trying to use in our daily life to he
 
 This rule checks if our connect (Flux) or selector implementation has all required dependencies, or if there is some dependency unused. If you are wondering, how this works in real life just ping us – [we are hiring.](https://www.productboard.com/careers/senior-javascript-developer-react-js/) 🤓
 
-### Configuration
+#### Configuration
 
 ```json
 {
@@ -25,7 +25,7 @@ This rule checks if our connect (Flux) or selector implementation has all requir
 }
 ```
 
-### Example
+#### Example
 
 ```text
 import { show, hide } from 'selectors/some';
@@ -43,7 +43,7 @@ export default compose(connect([show], () => ({
 
 This rule needs configuration for proper usage. Basically, you are able to set convention on how to group and sort imports based on the naming convention of imports. Check it out tests for the real-case usage.
 
-### Configuration
+#### Configuration
 
 ```json
 {
@@ -107,7 +107,7 @@ import { o } from "modules/views/constants/v";
 
 This rule checks if all connect (Flux) or selector dependencies are sorted alphabetically.
 
-### Configuration
+#### Configuration
 
 ```json
 {
@@ -123,7 +123,7 @@ This rule checks if all connect (Flux) or selector dependencies are sorted alpha
 }
 ```
 
-### Example
+#### Example
 
 ```text
 connect(
@@ -137,6 +137,74 @@ connect(
   ],
   () => {},
 )
+```
+
+### selectors-format
+
+To enforce some rules to our [selectors](https://github.com/productboard/pb-frontend/blob/master/docs/flux.md#selectors-1).
+
+1) **Dependency array must be defined as array literal.**
+It's better practice to have the list of dependencies inlined rather than in some variable outside of selector definition.
+
+2) **Dependency array must contain at least one dependency.**
+Otherwise it's probably misused selector and developer should use plain (possibly memoized) function.
+
+3) **Function in selector must be defined as arrow literal.**
+First for readability we want the function to be inlined and not defined outside of selector definition.
+Also, we don't wanna use `function` definition, to avoid possible `this` abuse.
+
+4) **Default arguments in selector function are forbidden.**
+Unfortunately, JavaScript doesn't play well with default arguments when using memoization on dynamic number of arguments. Therefore we have to disable it to prevent nasty bugs.
+
+5) **All arguments in selector function must be typed.**
+Unfortunately if you skip types on arguments, it just uses implicit `any` (probably because of generics used in `select` definition). It's potentially error-prone, so it's good idea to enforce it.
+
+#### Configuration
+
+```json
+{
+  "rules": {
+    "selectors-format": [
+      true,
+      {
+        "importsPaths": {
+          "select": ["libs/flux", "libs/flux/select"]
+        },
+        "reference": "Optional text to explain the error"
+      }
+    ]
+  }
+}
+```
+
+#### Example
+
+```text
+select(
+  FLUX_DEPENDENCIES,
+  ~~~~~~~~~~~~~~~~~  [Dependencies must be defined as array literal.]
+  () => {},
+);
+
+select(
+  [Store],
+  func,
+  ~~~~  [Function must be defined as arrow function literal.]
+);
+
+select(
+  [Store],
+  (a: number = 10) => false,
+   ~~~~~~~~~~~~~~            [Default arguments are forbidden.]
+);
+
+select(
+  [Store],
+  (abc, xyz) => false,
+   ~~~             [All arguments must be typed.]
+        ~~~        [All arguments must be typed.]
+);
+
 ```
 
 ## Install

--- a/src/rules/selectorsFormatRule.ts
+++ b/src/rules/selectorsFormatRule.ts
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2019-present, ProductBoard, Inc.
+ * All rights reserved.
+ */
+
+import * as Lint from 'tslint';
+import * as ts from 'typescript';
+
+export class Rule extends Lint.Rules.AbstractRule {
+  public apply(sourceFile: ts.SourceFile): Array<Lint.RuleFailure> {
+    return this.applyWithWalker(
+      new SelectorsFormatRule(sourceFile, this.getOptions()),
+    );
+  }
+}
+
+type Configuration = {
+  reference: string;
+  importPaths: { [key: string]: string | Array<string> };
+};
+
+class SelectorsFormatRule extends Lint.RuleWalker {
+  private configuration: Configuration;
+  private validIdentifiers: Set<string> = new Set();
+
+  constructor(sourceFile: ts.SourceFile, options: Lint.IOptions) {
+    super(sourceFile, options);
+
+    const configuration = {
+      reference: '',
+      ...options.ruleArguments[0],
+    } as Configuration;
+
+    if (!configuration.importPaths) {
+      throw new Error("'import-paths' option is mandatory.");
+    }
+
+    if (
+      typeof configuration.importPaths !== 'object' ||
+      Object.values(configuration.importPaths).some(
+        paths => typeof paths !== 'string' && !Array.isArray(paths),
+      )
+    ) {
+      throw new Error("Invalid 'import-paths' option format. Check docs for details please.");
+    }
+
+    this.configuration = configuration;
+
+    sourceFile.statements
+      .filter(ts.isImportDeclaration)
+      .forEach(({ importClause, moduleSpecifier }) => {
+        Object.entries(configuration.importPaths).forEach(([identifier, paths]) => {
+          if (typeof paths === 'string') paths = [paths];
+
+          if (
+            !importClause ||
+            !ts.isStringLiteral(moduleSpecifier) ||
+            !paths.some(path => path === moduleSpecifier.text)
+          ) {
+            return;
+          }
+
+          if (
+            (importClause.name && importClause.name.text === identifier) ||
+            (importClause.namedBindings &&
+              ts.isNamedImports(importClause.namedBindings) &&
+              importClause.namedBindings.elements.some(
+                importSpecifier => importSpecifier.name.text === identifier,
+              ))
+          ) {
+            this.validIdentifiers.add(identifier);
+          }
+        });
+      });
+  }
+
+  private getFormattedError(error: string): string {
+    return (
+      error +
+      (this.configuration.reference ? ` ${this.configuration.reference}` : '')
+    );
+  }
+
+  private checkDependenciesNode(dependenciesNode: ts.Node) {
+    if (!ts.isArrayLiteralExpression(dependenciesNode)) {
+      return this.addFailureAtNode(
+        dependenciesNode,
+        this.getFormattedError('Dependencies must be defined as array literal.'),
+      );
+    }
+
+    if (!dependenciesNode.elements.length) {
+      return this.addFailureAtNode(
+        dependenciesNode,
+        this.getFormattedError(
+          "Dependencies shouldn't be empty. You probably want to define plain function instead of a selector?",
+        ),
+      );
+    }
+  }
+
+  private checkResultFuncNode(resultFuncNode: ts.Node) {
+    if (!ts.isArrowFunction(resultFuncNode)) {
+      return this.addFailureAtNode(
+        resultFuncNode,
+        this.getFormattedError(
+          'Function must be defined as arrow function literal.',
+        ),
+      );
+    }
+
+    // check each parameter of function
+    resultFuncNode.parameters.forEach(paramNode => {
+      if (paramNode.initializer) {
+        this.addFailureAtNode(
+          paramNode,
+          this.getFormattedError('Default arguments are forbidden.'),
+        );
+      }
+
+      if (!paramNode.type) {
+        this.addFailureAtNode(
+          paramNode,
+          this.getFormattedError('All arguments must be typed.'),
+        );
+      }
+    });
+  }
+
+  public visitCallExpression(node: ts.CallExpression) {
+    const identifier = (node.expression as ts.Identifier).text;
+
+    if (
+      node.expression.kind === ts.SyntaxKind.Identifier &&
+      this.validIdentifiers.has(identifier)
+    ) {
+      if (node.arguments.length < 2) {
+        return this.addFailureAtNode(
+          node,
+          this.getFormattedError('Selector must have at least 2 arguments'),
+        );
+      }
+
+      this.checkDependenciesNode(node.arguments[0]);
+      this.checkResultFuncNode(node.arguments[1]);
+    }
+
+    super.visitCallExpression(node);
+  }
+}

--- a/test/rules/selectors-format-import-paths/test.1.tsx.lint
+++ b/test/rules/selectors-format-import-paths/test.1.tsx.lint
@@ -1,0 +1,7 @@
+import yoloselect from 'not-yoloselect-package';
+
+// Doesn't find any error because we don't check `select` here (see `import-paths` option)
+select('this', 'might', 'be', 'totally', 'ok');
+
+// Doesn't find any error because we are not importing from right package (see `import-paths` option)
+yoloselect(1, 2, 3);

--- a/test/rules/selectors-format-import-paths/test.2.tsx.lint
+++ b/test/rules/selectors-format-import-paths/test.2.tsx.lint
@@ -1,0 +1,9 @@
+import yoloselect from 'yoloselect';
+import { internalSelect } from 'libs/select';
+
+yoloselect();
+~~~~~~~~~~~~  [Selector must have at least 2 arguments]
+
+
+internalSelect();
+~~~~~~~~~~~~~~~~  [Selector must have at least 2 arguments]

--- a/test/rules/selectors-format-import-paths/tslint.json
+++ b/test/rules/selectors-format-import-paths/tslint.json
@@ -1,0 +1,13 @@
+{
+  "rules": {
+    "selectors-format": [
+      true,
+      {
+        "importPaths": {
+          "yoloselect": "yoloselect",
+          "internalSelect": "libs/select"
+        }
+      }
+    ]
+  }
+}

--- a/test/rules/selectors-format/test.1.tsx.lint
+++ b/test/rules/selectors-format/test.1.tsx.lint
@@ -1,0 +1,26 @@
+import select from 'select';
+
+select(
+  [Store],
+  () => {},
+);
+
+select(
+  [Store],
+  () => {},
+  noMemoize,
+);
+
+select(
+  [Store],
+  (a: number) => {
+    return ':)';
+  },
+);
+
+select(
+  [Store, selector],
+  (): boolean => {
+    return true;
+  },
+);

--- a/test/rules/selectors-format/test.2.tsx.lint
+++ b/test/rules/selectors-format/test.2.tsx.lint
@@ -1,0 +1,53 @@
+import select from 'select';
+
+select();
+~~~~~~~~  [Selector must have at least 2 arguments]
+select([Store]);
+~~~~~~~~~~~~~~~  [Selector must have at least 2 arguments]
+
+select(
+  [],
+  ~~  [Dependencies shouldn't be empty. You probably want to define plain function instead of a selector?]
+  (): boolean => {
+    return true;
+  },
+);
+
+const FLUX_DEPENDENCIES = [
+  Store,
+  selector,
+]
+
+select(
+  FLUX_DEPENDENCIES,
+  ~~~~~~~~~~~~~~~~~  [Dependencies must be defined as array literal.]
+  () => {},
+);
+
+const func = () => true;
+
+select(
+  [Store],
+  func,
+  ~~~~  [Function must be defined as arrow function literal.]
+  noMemoize,
+);
+
+select(
+  [Store],
+  function () { this.trololo = "dont!!" },
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [Function must be defined as arrow function literal.]
+);
+
+select(
+  [Store],
+  (a: number = 10) => false,
+   ~~~~~~~~~~~~~~            [Default arguments are forbidden.]
+);
+
+select(
+  [Store],
+  (abc, xyz) => false,
+   ~~~             [All arguments must be typed.]
+        ~~~        [All arguments must be typed.]
+);

--- a/test/rules/selectors-format/tslint.json
+++ b/test/rules/selectors-format/tslint.json
@@ -1,0 +1,12 @@
+{
+  "rules": {
+    "selectors-format": [
+      true,
+      {
+        "importPaths": {
+          "select": "select"
+        }
+      }
+    ]
+  }
+}

--- a/tslint-pb.json
+++ b/tslint-pb.json
@@ -3,6 +3,14 @@
   "rules": {
     "check-unused-flux-dependencies": true,
     "sort-flux-dependencies": true,
+    "selectors-format": [
+      true,
+      {
+        "importPaths": {
+          "select": ["libs/flux", "libs/flux/select"]
+        }
+      }
+    ],
     "import-group-order": [
       true,
       {


### PR DESCRIPTION
To enforce some rules to our [selectors](https://github.com/productboard/pb-frontend/blob/master/docs/flux.md#selectors-1).

1) **Dependency array must be defined as array literal.**
It's better practice to have the list of dependencies inlined rather than in some variable outside of selector definition.

2) **Dependency array must contain at least one dependency.**
Otherwise it's probably misused selector and developer should use plain (possibly memoized) function.

3) **Function in selector must be defined as arrow literal.**
First for readability we want the function to be inlined and not defined outside of selector definition.
Also, we don't wanna use `function` definition, to avoid possible `this` abuse.

4) **Default arguments in selector function are forbidden.**
Unfortunately, JavaScript doesn't play well with default arguments when using memoization on dynamic number of arguments. Therefore we have to disable it to prevent nasty bugs.

5) **All arguments in selector function must be typed.**
Unfortunately if you skip types on arguments, it just uses implicit `any` (probably because of generics used in `select` definition). It's potentially error-prone, so it's good idea to enforce it.

#### Configuration

```json
{
  "rules": {
    "selectors-format": [
      true,
      {
        "importsPaths": {
          "select": ["libs/flux", "libs/flux/select"]
        },
        "reference": "Optional text to explain the error"
      }
    ]
  }
}
```

#### Example

```text
select(
  FLUX_DEPENDENCIES,
  ~~~~~~~~~~~~~~~~~  [Dependencies must be defined as array literal.]
  () => {},
);

select(
  [Store],
  func,
  ~~~~  [Function must be defined as arrow function literal.]
);

select(
  [Store],
  (a: number = 10) => false,
   ~~~~~~~~~~~~~~            [Default arguments are forbidden.]
);

select(
  [Store],
  (abc, xyz) => false,
   ~~~             [All arguments must be typed.]
        ~~~        [All arguments must be typed.]
);

```