### PR TITLE
Fix the fixer :) for unsorted imports using `as` syntax

### DIFF
--- a/src/rules/importGroupOrderRule.ts
+++ b/src/rules/importGroupOrderRule.ts
@@ -59,6 +59,7 @@ type NormalizedConfiguration = {
 
 function formatImport(text: ImportType["i"]["text"], moduleSpecifier: string) {
   const namedImportsRegex = /{(.*)}/;
+  const asImportRegex = /as *(\w*)/;
   // let's omit the code style (new lines) entirely, it's prettier's job
   let inlinedText = text.replace(/\n/g, "");
 
@@ -70,7 +71,18 @@ function formatImport(text: ImportType["i"]["text"], moduleSpecifier: string) {
     .split(",")
     .map(a => a.trim())
     .filter(a => a)
-    .sort()
+    .map(imp => {
+      const matches = imp.match(asImportRegex);
+      if (matches && matches[1]) return [matches[1], imp];
+
+      return [imp];
+    })
+    .sort(([a], [b]) => {
+      if (a < b) return -1;
+      if (a > b) return 1;
+      return 0;
+    })
+    .map(([sortBase, imp]) => (imp ? imp : sortBase))
     .join(", ");
 
   // with syntax * as there might be moduleSpecifier ommited, so we need to reconstruct it.

--- a/test/rules/import-group-order/test.10.tsx.fix
+++ b/test/rules/import-group-order/test.10.tsx.fix
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+import { RandomGroupId, RandomGroup as TRandomGroup } from 'stores/RandomStore';
+
+import { createMagic } from 'constants/magic';
+
+console.log('ok');

--- a/test/rules/import-group-order/test.10.tsx.lint
+++ b/test/rules/import-group-order/test.10.tsx.lint
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+import { RandomGroup as TRandomGroup, RandomGroupId } from 'stores/RandomStore';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [Named imports are not sorted in alphabetical order]
+
+import { createMagic } from 'constants/magic';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [Import convention has been violated. This is auto-fixable.]
+
+console.log('ok');


### PR DESCRIPTION
Issue was correctly discovered, but fixer failed to sort it. Added test.