### PR TITLE
feat: Improved `selectors-format` rule to forbid optional arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,12 @@ select(
 
 select(
   [Store],
+  (a?: number) => false,
+   ~~~~~~~~~~                [Optional arguments are forbidden.]
+);
+
+select(
+  [Store],
   (abc, xyz) => false,
    ~~~             [All arguments must be typed.]
         ~~~        [All arguments must be typed.]

--- a/src/rules/selectorsFormatRule.ts
+++ b/src/rules/selectorsFormatRule.ts
@@ -118,6 +118,13 @@ class SelectorsFormatRule extends Lint.RuleWalker {
         );
       }
 
+      if (paramNode.questionToken) {
+        this.addFailureAtNode(
+          paramNode,
+          this.getFormattedError('Optional arguments are forbidden.'),
+        );
+      }
+
       if (!paramNode.type) {
         this.addFailureAtNode(
           paramNode,

--- a/test/rules/selectors-format/test.2.tsx.lint
+++ b/test/rules/selectors-format/test.2.tsx.lint
@@ -47,6 +47,12 @@ select(
 
 select(
   [Store],
+  (a?: number) => false,
+   ~~~~~~~~~~                [Optional arguments are forbidden.]
+);
+
+select(
+  [Store],
   (abc, xyz) => false,
    ~~~             [All arguments must be typed.]
         ~~~        [All arguments must be typed.]


### PR DESCRIPTION
Requested by @omackaj.

Now we can also prevent runtime error [_Inconsistent number of arguments passed to memoized selector._](https://github.com/productboard/pb-frontend/blob/92cd73160df454afd17e0dca70cb08556a0b48c0/src/js/libs/flux/select.ts#L135-L140) caused by optional arguments.

resolves #65