### PR TITLE
feat: Updated `selectors-format` rule to match new `select` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,8 +180,10 @@ To enforce some rules to our [selectors](https://github.com/productboard/pb-fron
    First for readability we want the function to be inlined and not defined outside of selector definition.
    Also, we don't wanna use `function` definition, to avoid possible `this` abuse.
 
-4. **Default arguments in selector function are forbidden.**
-   Unfortunately, JavaScript doesn't play well with default arguments when using memoization on dynamic number of arguments. Therefore we have to disable it to prevent nasty bugs.
+4. **Default/optional arguments in selector function are forbidden.**
+   Unfortunately, JavaScript doesn't play well with default/optional arguments when using memoization on dynamic number of arguments. Therefore we have to disable it to prevent nasty bugs.
+   
+   This is only forbidden for the default `select` with auto-memoization.
 
 5. **All arguments in selector function must be typed.**
    Unfortunately if you skip types on arguments, it just uses implicit `any` (probably because of generics used in `select` definition). It's potentially error-prone, so it's good idea to enforce it.

--- a/test/rules/selectors-format/test.1.tsx.lint
+++ b/test/rules/selectors-format/test.1.tsx.lint
@@ -5,10 +5,15 @@ select(
   () => {},
 );
 
-select(
+select.noMemo(
   [Store],
   () => {},
-  noMemoize,
+);
+
+select.customMemo(
+  [Store],
+  () => {},
+  () => 'key',
 );
 
 select(

--- a/test/rules/selectors-format/test.2.tsx.lint
+++ b/test/rules/selectors-format/test.2.tsx.lint
@@ -13,6 +13,23 @@ select(
   },
 );
 
+select.noMemo(
+  [],
+  ~~  [Dependencies shouldn't be empty. You probably want to define plain function instead of a selector?]
+  (): boolean => {
+    return true;
+  },
+);
+
+select.customMemo(
+  [],
+  ~~  [Dependencies shouldn't be empty. You probably want to define plain function instead of a selector?]
+  (): boolean => {
+    return true;
+  },
+  () => 'key',
+);
+
 const FLUX_DEPENDENCIES = [
   Store,
   selector,
@@ -24,13 +41,38 @@ select(
   () => {},
 );
 
+select.noMemo(
+  FLUX_DEPENDENCIES,
+  ~~~~~~~~~~~~~~~~~  [Dependencies must be defined as array literal.]
+  () => {},
+);
+
+select.customMemo(
+  FLUX_DEPENDENCIES,
+  ~~~~~~~~~~~~~~~~~  [Dependencies must be defined as array literal.]
+  () => {},
+  () => 'key',
+);
+
 const func = () => true;
 
 select(
   [Store],
   func,
   ~~~~  [Function must be defined as arrow function literal.]
-  noMemoize,
+);
+
+select.noMemo(
+  [Store],
+  func,
+  ~~~~  [Function must be defined as arrow function literal.]
+);
+
+select.customMemo(
+  [Store],
+  func,
+  ~~~~  [Function must be defined as arrow function literal.]
+  () => 'key',
 );
 
 select(
@@ -39,16 +81,51 @@ select(
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [Function must be defined as arrow function literal.]
 );
 
+select.noMemo(
+  [Store],
+  function () { this.trololo = "dont!!" },
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [Function must be defined as arrow function literal.]
+);
+
+select.customMemo(
+  [Store],
+  function () { this.trololo = "dont!!" },
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  [Function must be defined as arrow function literal.]
+  () => 'key',
+);
+
 select(
   [Store],
   (a: number = 10) => false,
-   ~~~~~~~~~~~~~~            [Default arguments are forbidden.]
+   ~~~~~~~~~~~~~~            [Default arguments are forbidden for default select with auto-memoization.]
+);
+
+select.noMemo(
+  [Store],
+  (a: number = 10) => false,
+);
+
+select.customMemo(
+  [Store],
+  (a: number = 10) => false,
+  () => String(a),
 );
 
 select(
   [Store],
   (a?: number) => false,
-   ~~~~~~~~~~                [Optional arguments are forbidden.]
+   ~~~~~~~~~~                [Optional arguments are forbidden for default select with auto-memoization.]
+);
+
+select.noMemo(
+  [Store],
+  (a?: number) => false,
+);
+
+select.customMemo(
+  [Store],
+  (a?: number) => false,
+  () => typeof a === 'number' ? String(a) : '🤷‍',
 );
 
 select(
@@ -56,4 +133,19 @@ select(
   (abc, xyz) => false,
    ~~~             [All arguments must be typed.]
         ~~~        [All arguments must be typed.]
+);
+
+select.noMemo(
+  [Store],
+  (abc, xyz) => false,
+   ~~~             [All arguments must be typed.]
+        ~~~        [All arguments must be typed.]
+);
+
+select.customMemo(
+  [Store],
+  (abc, xyz) => false,
+   ~~~             [All arguments must be typed.]
+        ~~~        [All arguments must be typed.]
+  (abc, xyz => `${abc}|${xyz}`,
 );


### PR DESCRIPTION
There is new `select` API as a result of RFC: Objects as arguments in selectors (https://github.com/productboard/pb-frontend/pull/7480)
This commit updates the Lint rule to cover the new functionality.