### PR TITLE
fix: Support of new `select` API for all rules 

### DIFF
--- a/src/utils/connectUtils.ts
+++ b/src/utils/connectUtils.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) ProductBoard, Inc.
+ * All rights reserved.
+ */
+
+import * as ts from 'typescript';
+
+const DEFAULT_CONNECT_NAME = 'connect';
+
+export const getConnectMetadata = (
+  node: ts.CallExpression,
+) => {
+  if (
+    !ts.isIdentifier(node.expression) ||
+    node.expression.text !== DEFAULT_CONNECT_NAME
+  ) {
+    return null;
+  }
+
+  return {
+    identifierExpression: node.expression,
+  }
+}

--- a/src/utils/selectUtils.ts
+++ b/src/utils/selectUtils.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) ProductBoard, Inc.
+ * All rights reserved.
+ */
+
+import * as ts from 'typescript';
+
+const DEFAULT_SELECT_NAME = 'select';
+const VALID_PROPERTY_NAMES = new Set(['noMemo', 'customMemo']);
+
+export const getSelectMetadata = (
+  node: ts.CallExpression,
+  validIdentifiers: Set<string> = new Set([DEFAULT_SELECT_NAME]),
+) => {
+  const identifierExpression =
+    ts.isPropertyAccessExpression(node.expression) &&
+    VALID_PROPERTY_NAMES.has(node.expression.name.text)
+      ? node.expression.expression
+      : node.expression;
+
+  if (
+    !ts.isIdentifier(identifierExpression) ||
+    !validIdentifiers.has(identifierExpression.text)
+  ) {
+    return null;
+  }
+
+  const variableName =
+    ts.isVariableDeclaration(node.parent) && ts.isIdentifier(node.parent.name)
+      ? node.parent.name.text
+      : null;
+
+  return {
+    identifierExpression,
+    hasNoMemo:
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === 'noMemo',
+    hasCustomMemo:
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === 'customMemo',
+    variableName,
+  };
+};

--- a/test/rules/check-unused-flux-dependencies/test.10.tsx.lint
+++ b/test/rules/check-unused-flux-dependencies/test.10.tsx.lint
@@ -8,7 +8,7 @@ const superSelect = select([show, hide], () => {
 })
 
 export default connect([show, hide, superSelect], () => ({
-                                    ~~~~~~~~~~~            [The "superSelect" dependency  is unused. This has performance impact!]
+                                    ~~~~~~~~~~~   [The "superSelect" dependency  is unused. This has performance impact!]
   a: show(),
   b: hide(),
 }))(component);
@@ -18,4 +18,48 @@ export default connect([show, hide], () => ({
   b: hide(),
   b: superSelect()
      ~~~~~~~~~~~   [You forgot to listen for the "superSelect" dependency!]
+}))(component);
+
+
+
+const superSelectNoMemo = select.noMemo([show, hide], () => {
+  return {
+    a: show(),
+    b: hide(),
+  }
+})
+
+export default connect([show, hide, superSelectNoMemo], () => ({
+                                    ~~~~~~~~~~~~~~~~~   [The "superSelectNoMemo" dependency  is unused. This has performance impact!]
+  a: show(),
+  b: hide(),
+}))(component);
+
+export default connect([show, hide], () => ({
+  a: show(),
+  b: hide(),
+  b: superSelectNoMemo()
+     ~~~~~~~~~~~~~~~~~   [You forgot to listen for the "superSelectNoMemo" dependency!]
+}))(component);
+
+
+
+const superSelectCustomMemo = select.customMemo([show, hide], () => {
+  return {
+    a: show(),
+    b: hide(),
+  }
+}, () => 'memoKey')
+
+export default connect([show, hide, superSelectCustomMemo], () => ({
+                                    ~~~~~~~~~~~~~~~~~~~~~   [The "superSelectCustomMemo" dependency  is unused. This has performance impact!]
+  a: show(),
+  b: hide(),
+}))(component);
+
+export default connect([show, hide], () => ({
+  a: show(),
+  b: hide(),
+  b: superSelectCustomMemo()
+     ~~~~~~~~~~~~~~~~~~~~~   [You forgot to listen for the "superSelectCustomMemo" dependency!]
 }))(component);

--- a/test/rules/check-unused-flux-dependencies/test.5.tsx.lint
+++ b/test/rules/check-unused-flux-dependencies/test.5.tsx.lint
@@ -5,3 +5,19 @@ export default select([show], () => ({
   b: hide(),
      ~~~~    [You forgot to listen for the "hide" dependency!]
 }))
+
+export default select.noMemo([show], () => ({
+  a: show(),
+  b: hide(),
+     ~~~~    [You forgot to listen for the "hide" dependency!]
+}))
+
+export default select.customMemo(
+  [show],
+  () => ({
+    a: show(),
+    b: hide(),
+       ~~~~    [You forgot to listen for the "hide" dependency!]
+  }),
+  () => 'memoKey',
+)

--- a/test/rules/check-unused-flux-dependencies/test.6.tsx.lint
+++ b/test/rules/check-unused-flux-dependencies/test.6.tsx.lint
@@ -6,3 +6,19 @@ export default select([show, hide], () => ({
   b: hide(),
   c: NotADependency()
 }))
+
+export default select.noMemo([show, hide], () => ({
+  a: show(),
+  b: hide(),
+  c: NotADependency()
+}))
+
+export default select.customMemo(
+  [show, hide],
+  () => ({
+    a: show(),
+    b: hide(),
+    c: NotADependency()
+  }),
+  () => 'memoKey',
+)

--- a/test/rules/check-unused-flux-dependencies/test.7.tsx.lint
+++ b/test/rules/check-unused-flux-dependencies/test.7.tsx.lint
@@ -10,3 +10,27 @@ export default select([show, hide, SuperStore], () => {
     c: swag(),
   }
 })
+
+export default select.noMemo([show, hide, SuperStore], () => {
+  const swag = SuperStore.magic;
+
+  return {
+    a: show(),
+    b: hide(),
+    c: swag(),
+  }
+})
+
+export default select.customMemo(
+  [show, hide, SuperStore],
+  () => {
+    const swag = SuperStore.magic;
+
+    return {
+      a: show(),
+      b: hide(),
+      c: swag(),
+    }
+  },
+  () => 'memoKey',
+)

--- a/test/rules/check-unused-flux-dependencies/test.8.tsx.lint
+++ b/test/rules/check-unused-flux-dependencies/test.8.tsx.lint
@@ -19,3 +19,47 @@ export default select([anotherSelect], () => {
     magic: anotherSelect(),
   }
 })
+
+
+
+const anotherSelectNoMemo = select.noMemo([show, hide], () => {
+  return {
+    a: show(),
+    b: hide(),
+  }
+})
+
+export default select([anotherSelectNoMemo], () => {
+  return {
+    magic: anotherSelectNoMemo(),
+  }
+})
+
+export default select([anotherSelectNoMemo], () => {
+  return {
+    show: "must go on",
+    magic: anotherSelectNoMemo(),
+  }
+})
+
+
+
+const anotherSelectCustomMemo = select([show, hide], () => {
+  return {
+    a: show(),
+    b: hide(),
+  }
+})
+
+export default select([anotherSelectCustomMemo], () => {
+  return {
+    magic: anotherSelectCustomMemo(),
+  }
+})
+
+export default select([anotherSelectCustomMemo], () => {
+  return {
+    show: "must go on",
+    magic: anotherSelectCustomMemo(),
+  }
+}, () => 'memoKey')

--- a/test/rules/check-unused-flux-dependencies/test.9.tsx.lint
+++ b/test/rules/check-unused-flux-dependencies/test.9.tsx.lint
@@ -13,3 +13,35 @@ export default select([], () => {
            ~~~~~~~~~~~~~    [You forgot to listen for the "anotherSelect" dependency!]
   }
 })
+
+
+
+const anotherSelectNoMemo = select.noMemo([show, hide], () => {
+  return {
+    a: show(),
+    b: hide(),
+  }
+})
+
+export default select([], () => {
+  return {
+    magic: anotherSelectNoMemo(),
+           ~~~~~~~~~~~~~~~~~~~    [You forgot to listen for the "anotherSelectNoMemo" dependency!]
+  }
+})
+
+
+
+const anotherSelectCustomMemo = select.customMemo([show, hide], () => {
+  return {
+    a: show(),
+    b: hide(),
+  }
+}, () => 'memoKey')
+
+export default select([], () => {
+  return {
+    magic: anotherSelectCustomMemo(),
+           ~~~~~~~~~~~~~~~~~~~~~~~    [You forgot to listen for the "anotherSelectCustomMemo" dependency!]
+  }
+})

--- a/test/rules/sort-flux-dependencies/test.1.tsx.fix
+++ b/test/rules/sort-flux-dependencies/test.1.tsx.fix
@@ -14,6 +14,8 @@ connect(
   () => {},
 )
 
+
+
 select(
   [
     AStore, getA,
@@ -34,4 +36,55 @@ select(
     getA,
   ],
   () => {},
+)
+
+
+
+select.noMemo(
+  [
+    AStore, getA,
+  ],
+  () => {},
+)
+
+select.noMemo(
+  [
+    BStore, AStore, ...weirdMagic,
+  ],
+  () => {},
+)
+
+select.noMemo(
+  [
+    AStore,
+    getA,
+  ],
+  () => {},
+)
+
+
+
+select.customMemo(
+  [
+    AStore, getA,
+  ],
+  () => {},
+  () => 'memoKey',
+)
+
+select.customMemo(
+  [
+    BStore, AStore, ...weirdMagic,
+  ],
+  () => {},
+  () => 'memoKey',
+)
+
+select.customMemo(
+  [
+    AStore,
+    getA,
+  ],
+  () => {},
+  () => 'memoKey',
 )

--- a/test/rules/sort-flux-dependencies/test.1.tsx.lint
+++ b/test/rules/sort-flux-dependencies/test.1.tsx.lint
@@ -7,13 +7,15 @@ connect(
   [
     AlonglonglongStore,
     getLongLongLongA,
-    ~~~~~~~~~~~~~~~~  [Dependency array is not sorted correctly!] 
+    ~~~~~~~~~~~~~~~~  [Dependency array is not sorted correctly!]
     BlonglonglongStore,
     getLongLongLongB,
     getLongLongLongC,
   ],
   () => {},
 )
+
+
 
 select(
   [
@@ -37,4 +39,59 @@ select(
     getA,
   ],
   () => {},
+)
+
+
+
+select.noMemo(
+  [
+    getA,
+    ~~~~  [Dependency array is not sorted correctly!]
+    AStore,
+  ],
+  () => {},
+)
+
+select.noMemo(
+  [
+    BStore, AStore, ...weirdMagic,
+  ],
+  () => {},
+)
+
+select.noMemo(
+  [
+    AStore,
+    getA,
+  ],
+  () => {},
+)
+
+
+
+select.customMemo(
+  [
+    getA,
+    ~~~~  [Dependency array is not sorted correctly!]
+    AStore,
+  ],
+  () => {},
+  () => 'memoKey',
+)
+
+select.customMemo(
+  [
+    BStore, AStore, ...weirdMagic,
+  ],
+  () => {},
+  () => 'memoKey',
+)
+
+select.customMemo(
+  [
+    AStore,
+    getA,
+  ],
+  () => {},
+  () => 'memoKey',
 )


### PR DESCRIPTION
After merging the [`rfc: Objects as arguments in selectors`](https://github.com/productboard/pb-frontend/pull/7480), I [updated the `selectors-format` rule](https://github.com/productboardlabs/tslint-pb/pull/67) to match the new `select` API.

Unfortunately, I missed another two rules, which work with `select`, resulting in insufficient linting.
Reported by @tomsvob: https://github.com/productboard/pb-frontend/pull/7914#discussion_r419274033

In this PR I am implementing the support of the new `select` API for these 2 remaining lint rules.

Also, I introduced `utils/connectUtils` and `utils/selectUtils` to unify some common logic of detecting `connect`/`select` CallExpressions.

---

And also there are quite a lot of syntax changes, as I ran prettier on the existing files, which were not prettified before.

💡Idea: Let's introduce official `prettier` support for this repo?
Edit: I see we already track this (https://github.com/productboardlabs/tslint-pb/issues/51)