### PR TITLE
Fix lint rule for `noMemo` selector with default values

### DIFF
--- a/src/rules/selectorsFormatRule.ts
+++ b/src/rules/selectorsFormatRule.ts
@@ -131,8 +131,7 @@ class SelectorsFormatRule extends Lint.RuleWalker {
           ),
         );
       }
-
-      if (!paramNode.type) {
+      if (!paramNode.type && !paramNode.initializer) {
         this.addFailureAtNode(
           paramNode,
           this.getFormattedError('All arguments must be typed.'),

--- a/test/rules/selectors-format/test.2.tsx.lint
+++ b/test/rules/selectors-format/test.2.tsx.lint
@@ -100,14 +100,31 @@ select(
    ~~~~~~~~~~~~~~            [Default arguments are forbidden for default select with auto-memoization.]
 );
 
+select(
+  [Store],
+  (a = 10) => false,
+   ~~~~~~                    [Default arguments are forbidden for default select with auto-memoization.]
+);
+
 select.noMemo(
   [Store],
   (a: number = 10) => false,
 );
 
+select.noMemo(
+  [Store],
+  (a = 10) => false,
+);
+
 select.customMemo(
   [Store],
   (a: number = 10) => false,
+  () => String(a),
+);
+
+select.customMemo(
+  [Store],
+  (a = 10) => false,
   () => String(a),
 );
 


### PR DESCRIPTION
`noMemo` is supposed to allow default values. Covered in [tests](https://github.com/productboardlabs/tslint-pb/blob/master/test/rules/selectors-format/test.2.tsx.lint#L105):

```typescript
select.noMemo(
  [Store],
  (a: number = 10) => false,
);
```

But typical usage is with inferred type:

```typescript
select.noMemo(
  [Store],
  (a = 10) => false,
);
```

which was not allowed. This PR allows inferred type for default parameter in the selector.