### PR TITLE
chore: add link to TS AST viewer to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ _tslint.json_
 
 ## Contribution
 
-There are test provided, just run `yarn run test`. For quick prototyping use http://astexplorer.net – it's a great tool! Any contribution welcomed! 🙏
+There are test provided, just run `yarn run test`. For quick prototyping use <http://astexplorer.net> or <https://ts-ast-viewer.com> for TS – those are great tools! Any contribution welcomed! 🙏
 
 ## License
 


### PR DESCRIPTION
https://astexplorer.net mentioned in readme doesn't support TS. Maybe it would be better to remove it completely.